### PR TITLE
Make sure to copy propTypes

### DIFF
--- a/src/applyContainerQuery.js
+++ b/src/applyContainerQuery.js
@@ -22,7 +22,7 @@ export default function applyContainerQuery(
   {propName = 'containerQuery', setAttribute} = {}) {
 
   return createClass({
-
+    propTypes: Container.propTypes,
     displayName: 'ContainerQuery',
     mixins: [createContainerQueryMixin(query, {setAttribute})],
 


### PR DESCRIPTION
I'm using a library that depends on the propTypes being defined properly.