### PR TITLE
Enhance display name for improved React warnings.

### DIFF
--- a/src/applyContainerQuery.ts
+++ b/src/applyContainerQuery.ts
@@ -10,7 +10,7 @@ export default function<P> (
 
   return React.createClass<P, any>({
     propTypes: Component.propTypes,
-    displayName: 'ContainerQuery',
+    displayName: 'ContainerQuery(' + getDisplayName(WrappedComponent) + ')',
     mixins: [createContainerQueryMixin(query)],
 
     defineContainerComponent(ref: React.Component<any, any>) {
@@ -23,4 +23,8 @@ export default function<P> (
       return React.createElement(Component, props as P);
     }
   });
+}
+
+function getDisplayName(WrappedComponent: React.ComponentClass<P>) {
+  return WrappedComponent.displayName || WrappedComponent.name || 'Component';
 }

--- a/src/applyContainerQuery.ts
+++ b/src/applyContainerQuery.ts
@@ -10,7 +10,7 @@ export default function<P> (
 
   return React.createClass<P, any>({
     propTypes: Component.propTypes,
-    displayName: 'ContainerQuery(' + getDisplayName(WrappedComponent) + ')',
+    displayName: 'ContainerQuery(' + getDisplayName(Component) + ')',
     mixins: [createContainerQueryMixin(query)],
 
     defineContainerComponent(ref: React.Component<any, any>) {
@@ -25,6 +25,6 @@ export default function<P> (
   });
 }
 
-function getDisplayName(WrappedComponent: React.ComponentClass<P>) {
-  return WrappedComponent.displayName || WrappedComponent.name || 'Component';
+function getDisplayName(WrappedComponent: React.ComponentClass<any>) {
+  return WrappedComponent.displayName || 'Component';
 }


### PR DESCRIPTION
In development mode React will provide warnings such as the following:

     Error: Warning: Failed propType: Required prop `someProp` was not specified in `Connect(ContainerQuery)`. Check the render method of `Connect(ContainerQuery)`.

Before this change the warning would look like the above and you would not get the name of the component that is wrapped in the ContainerQuery.  After this change you get more information like below:

     Error: Warning: Failed propType: Required prop `someProp` was not specified in `Connect(ContainerQuery(MyComponent)))`. Check the render method of `Connect(ContainerQuery(MyComponent)))`.

This allows you to see exactly which component issued the warning.