### PR TITLE
Add support for stateless components

### DIFF
--- a/package.json
+++ b/package.json
@@ -64,6 +64,7 @@
     "karma-webpack": "1.8.0",
     "onchange": "3.0.2",
     "react": "15.3.2",
+    "react-addons-test-utils": "^15.3.2",
     "react-dom": "15.3.2",
     "rimraf": "2.5.4",
     "tslint": "3.15.1",

--- a/src/applyContainerQuery.ts
+++ b/src/applyContainerQuery.ts
@@ -17,9 +17,11 @@ export default function<P> (
     },
 
     render() {
-      const props: {[key: string]: any} = assign({ref: this.defineContainerComponent}, this.props);
+      const props: {[key: string]: any} = assign({}, this.props);
       props[propName] = this.state ? this.state.containerQuery : {};
-      return React.createElement(WrappedComponent, props as P);
+      return React.createElement('div', {
+        ref: this.defineContainerComponent
+      }, React.createElement(WrappedComponent, props as P));
     }
   });
 }

--- a/test/src/applyContainerQuery.test.js
+++ b/test/src/applyContainerQuery.test.js
@@ -1,5 +1,6 @@
 import React, {Component} from 'react';
 import {render, findDOMNode} from 'react-dom';
+import { findRenderedComponentWithType } from 'react-addons-test-utils';
 import classnames from 'classnames';
 import applyContainerQuery from '../../lib/applyContainerQuery';
 
@@ -19,12 +20,17 @@ describe('applyContainerQuery', function () {
     });
 
     let div;
+    let renderOutput;
+    let intermediateNode;
     let containerNode;
 
     beforeEach(function () {
       div = document.createElement('div');
       document.body.appendChild(div);
-      containerNode = findDOMNode(render(<ContainerQuery/>, div));
+      renderOutput = render(<ContainerQuery/>, div);
+      intermediateNode = findDOMNode(renderOutput);
+      intermediateNode.style.display = 'inline-block';
+      containerNode = findDOMNode(findRenderedComponentWithType(renderOutput, Container));
     });
 
     afterEach(function () {
@@ -67,12 +73,17 @@ describe('applyContainerQuery', function () {
     });
 
     let div;
+    let renderOutput;
+    let intermediateNode;
     let containerNode;
 
     beforeEach(function () {
       div = document.createElement('div');
       document.body.appendChild(div);
-      containerNode = findDOMNode(render(<ContainerQuery/>, div));
+      renderOutput = render(<ContainerQuery/>, div);
+      intermediateNode = findDOMNode(renderOutput);
+      intermediateNode.style.display = 'inline-block';
+      containerNode = findDOMNode(findRenderedComponentWithType(renderOutput, Container));
     });
 
     afterEach(function () {
@@ -119,9 +130,18 @@ describe('applyContainerQuery', function () {
     let div;
 
     function renderContainerQuery(props) {
-      return findDOMNode(render(
-        <ContainerQuery other1={props.other1} other2={props.other2} />,
-        div));
+      return findDOMNode(
+        findRenderedComponentWithType(
+          render(
+            <ContainerQuery
+              other1={props.other1}
+              other2={props.other2}
+            />,
+            div
+          ),
+          Container
+        )
+      );
     }
 
     beforeEach(function () {
@@ -187,10 +207,18 @@ describe('applyContainerQuery', function () {
     let div;
 
     function renderContainerQuery(props) {
-      return findDOMNode(render(
-        <ContainerQuery other1={props.other1} other2={props.other2} />,
-        div
-      ));
+      return findDOMNode(
+        findRenderedComponentWithType(
+          render(
+            <ContainerQuery
+              other1={props.other1}
+              other2={props.other2}
+            />,
+            div
+          ),
+          Container
+        )
+      );
     }
 
     beforeEach(function () {
@@ -203,9 +231,57 @@ describe('applyContainerQuery', function () {
     });
 
     it('should allow wrapped component to return null', function () {
-      const node = renderContainerQuery({other1: 'hello', other2: 'world'});
+      const containerNode = renderContainerQuery({other1: 'hello', other2: 'world'});
 
-      expect(node).toBeNull();
+      expect(containerNode).toBeNull();
+    });
+
+  });
+
+
+  describe('works with a stateless component', function () {
+
+    const Container = (props) => <div className={classnames(props.containerQuery)}></div>;
+
+    const ContainerQuery = applyContainerQuery(Container, {
+      mobile: {maxWidth: 399},
+      desktop: {minWidth: 400}
+    });
+
+    let div;
+    let renderOutput;
+    let intermediateNode;
+    let containerNode;
+
+    beforeEach(function () {
+      div = document.createElement('div');
+      document.body.appendChild(div);
+      renderOutput = render(<ContainerQuery/>, div);
+      intermediateNode = findDOMNode(renderOutput);
+      intermediateNode.style.display = 'inline-block';
+      containerNode = intermediateNode.querySelector('div');
+    });
+
+    afterEach(function () {
+      document.body.removeChild(div);
+    });
+
+    it('sets container className to mobile', function (done) {
+      containerNode.style.width = '200px';
+
+      setTimeout(() => {
+        expect(containerNode.className).toBe('mobile');
+        done();
+      }, 1000);
+    });
+
+    it('sets container className to desktop', function (done) {
+      containerNode.style.width = '500px';
+
+      setTimeout(() => {
+        expect(containerNode.className).toBe('desktop');
+        done();
+      }, 1000);
     });
 
   });


### PR DESCRIPTION
Addresses #15 & #30 by allowing for stateless components to be used as the `Container`. This does make the query fire from the width of it's parent, i.e., the intermediate HoC rather than the `Container` itself, but the added flexibility is a good pay off imho.

I've added `react-addons-test-utils` also, for the use of `findRenderedComponentWithType` which makes the tests make a lot more sense with the addition of the intermediate HoC.

Props to @moimael for the suggested solution. 