### PR TITLE
Move @types packages to devDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,15 +28,15 @@
     "src"
   ],
   "dependencies": {
-    "@types/classnames": "0.0.31",
-    "@types/lodash": "4.*",
-    "@types/react": "0.14.*",
     "classnames": "2.*",
     "container-query-toolkit": "0.0.2",
     "lodash": "4.*",
     "resize-observer-lite": "0.0.1"
   },
   "devDependencies": {
+    "@types/classnames": "0.0.31",
+    "@types/lodash": "4.*",
+    "@types/react": "0.14.*",
     "babel-cli": "6.18.0",
     "babel-core": "6.18.0",
     "babel-eslint": "7.1.0",


### PR DESCRIPTION
#### What does this PR do?

Move @types packages to `devDependencies`

#### Any background context you want to provide?

Currently unable to install package from npm.

![screen shot 2016-11-10 at 11 03 25 am](https://cloud.githubusercontent.com/assets/202773/20188335/6db70318-a735-11e6-9b7e-647b249a2a8f.png)