### PR TITLE
Support server side rendering with values prop

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ npm i -D react-container-query
 
 ## API
 
-### `<ContainerQuery query={query}>`
+### `<ContainerQuery query={query} values={{width, height}}>`
 
 ```jsx
 import React, {Component} from 'react';
@@ -72,7 +72,12 @@ render(<MyComponent/>, document.getElementById('app'));
 
     "query" is key-value pairs where keys are the class names that will be applied to container element when all constraints are met. The values are the constraints.
 
-### `applyContainerQuery(Component, query) -> ReactComponent`
+- `props.values`
+
+    "values" is an object with optional `width` and/or `height` keys used as
+    defaults to support server side rendering.
+
+### `applyContainerQuery(Component, query, values) -> ReactComponent`
 
 ```jsx
 import React, {Component} from 'react';
@@ -142,6 +147,8 @@ With below CSS, `.box` will be blue when `.container` is wider than 600px, green
   }
 }
 ```
+
+_Note: This library does *not* provide these CSS features._
 
 ## Demo
 

--- a/config/webpack.config.development.js
+++ b/config/webpack.config.development.js
@@ -1,5 +1,6 @@
 'use strict';
 
+// eslint-disable-next-line import/no-extraneous-dependencies
 const webpack = require('webpack');
 const baseConfig = require('./webpack.config.base');
 

--- a/config/webpack.config.production.js
+++ b/config/webpack.config.production.js
@@ -1,5 +1,6 @@
 'use strict';
 
+// eslint-disable-next-line import/no-extraneous-dependencies
 const webpack = require('webpack');
 const baseConfig = require('./webpack.config.base');
 

--- a/src/ContainerQueryCore.ts
+++ b/src/ContainerQueryCore.ts
@@ -12,9 +12,13 @@ export default class ContainerQueryCore {
       const result = matchQueries(query)(size);
       if (!isEqual(this.result, result)) {
         callback(result);
-        this.result = result;
+        this.storeParams(result);
       }
     });
+  }
+
+  storeParams(params: Params) {
+    this.result = params;
   }
 
   observe(element: Element) {

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,10 +1,31 @@
 import React = require('react');
 import ReactDOM = require('react-dom');
-import {Props, State, Params, Query} from './interfaces';
+import omitBy = require('lodash/omitBy');
+import matchQueries from 'container-query-toolkit/lib/matchQueries';
+import {Props, State, Params, Query, Values} from './interfaces';
 import ContainerQueryCore from './ContainerQueryCore';
 
+function cleanParams(query: Query, params: Params, width: number, height: number): Params {
+  // Clean up any matches that include a query for a value we don't yet have
+  if (width === Infinity) {
+    params = omitBy(params, (_, key: string): boolean => (
+      typeof query[key].minWidth !== 'undefined'
+      || typeof query[key].maxWidth !== 'undefined'
+    )) as Params;
+  }
+
+  if (height === Infinity) {
+    params = omitBy(params, (_, key: string): boolean => (
+      typeof query[key].minHeight !== 'undefined'
+      || typeof query[key].maxHeight !== 'undefined'
+    )) as Params;
+  }
+
+  return params;
+}
+
 /**
- * <ContainerQuery query={query}>
+ * <ContainerQuery query={query} values={{width: 123, height: 456}}>
  *   {(params) => {
  *     <div className={classname(params.class)}></div>
  *   }}
@@ -16,16 +37,27 @@ export class ContainerQuery extends React.Component<Props, State> {
 
   constructor(props: Props) {
     super(props);
-    this.state = {
-      params: {}
-    };
+    const {width = Infinity, height = Infinity}: {width?: number, height?: number} = (props.values || {});
+
+    if (width === Infinity && height === Infinity) {
+      this.state = {
+        params: {}
+      };
+      return;
+    }
+
+    let params: Params = matchQueries(props.query)({width, height});
+
+    params = cleanParams(props.query, params, width, height);
+
+    this.setState({params});
   }
 
   componentDidMount() {
     this.cqCore = new ContainerQueryCore(this.props.query, (params) => {
       this.setState({params});
     });
-
+    this.cqCore.storeParams(this.state.params);
     this.cqCore.observe(ReactDOM.findDOMNode(this));
   }
 
@@ -49,7 +81,8 @@ export class ContainerQuery extends React.Component<Props, State> {
 
 export function applyContainerQuery<P extends {containerQuery: Params}>(
   Component: React.ComponentClass<P>,
-  query: Query
+  query: Query,
+  values?: Values
 ): React.ComponentClass<P> {
   class ContainerQuery extends React.Component<P, State> {
     static displayName: string = Component.displayName
@@ -60,16 +93,28 @@ export function applyContainerQuery<P extends {containerQuery: Params}>(
 
     constructor(props: P) {
       super(props);
-      this.state = {
-        params: {}
-      };
+
+      const {width = Infinity, height = Infinity}: {width?: number, height?: number} = (values || {});
+
+      if (width === Infinity && height === Infinity) {
+        this.state = {
+          params: {}
+        };
+        return;
+      }
+
+      let params: Params = matchQueries(query)({width, height});
+
+      params = cleanParams(query, params, width, height);
+
+      this.setState({params});
     }
 
     componentDidMount() {
       this.cqCore = new ContainerQueryCore(query, (params) => {
         this.setState({params});
       });
-
+      this.cqCore.storeParams(this.state.params);
       this.cqCore.observe(ReactDOM.findDOMNode(this));
     }
 

--- a/src/interfaces.tsx
+++ b/src/interfaces.tsx
@@ -1,6 +1,12 @@
 export interface Props {
   children: ChildFunction;
   query: Query;
+  values?: Values;
+}
+
+export interface Values {
+  width?: number;
+  height?: number;
 }
 
 export interface State {


### PR DESCRIPTION
Using a similar API to [`react-responsive`'s server side rendering support](https://github.com/contra/react-responsive#server-rendering), this change enables the following (modified from the example in `README.md`):

```javascript
import React, {Component} from 'react';
import {render} from 'react-dom';
import {ContainerQuery} from 'react-container-query';
import classnames from 'classnames';

const query = {
  'width-between-400-and-599': {
    minWidth: 400,
    maxWidth: 599
  },
  'width-larger-than-600': {
    minWidth: 600,
  }
};

function MyComponent() {
  /**
   * Given a client side container width of 700, but default server side width of 500;
   *
   * On server side rendering, `params` in the children function will look like
   * {
   *   'width-between-400-and-599': true,
   *   'width-larger-than-600': false
   * }
   *
   * After mounting on the client, `params` in the children function will look like
   * {
   *   'width-between-400-and-599': false,
   *   'width-larger-than-600': true
   * }
   */
  return (
    <ContainerQuery query={query} values={{width: 500}}>
      {(params) => (
        <div className={classnames(params)}>the box</div>
      )}
    </ContainerQuery>
  );
};

/**
 * Given a client side container width of 700, but default server side width of 500;
 *
 * Server side rendering will generate following HTML:
 * <div class="width-between-400-and-599">the box</div>
 *
 * After mounting, will generate following HTML:
 * <div class="width-larger-than-600">the box</div>
 */

render(<MyComponent/>, document.getElementById('app'));
```

*Note*: I have no idea how to unit test this (but all the existing tests pass) :/
