### PR TITLE
Pass query as prop with applyContainerQuery

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -5,7 +5,7 @@
     },
     "test": {
       "presets": ["react", "es2015"],
-      "plugins": [["__coverage__", {"ignore": "test/"}]]
+      "plugins": [["__coverage__", {"ignore": "test/"}], ["transform-object-rest-spread", { "useBuiltIns": true }]]
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "babel-eslint": "7.2.3",
     "babel-loader": "6.3.2",
     "babel-plugin-__coverage__": "11.0.0",
+    "babel-plugin-transform-object-rest-spread": "^6.26.0",
     "babel-preset-es2015": "6.24.1",
     "babel-preset-es2015-loose": "8.0.0",
     "babel-preset-react": "6.24.1",

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -55,11 +55,12 @@ export type Component<T> = React.ComponentClass<T> | React.StatelessComponent<T>
 
 export interface QueryProps {
   containerQuery: Params;
+  query?: Query;
 };
 
 export function applyContainerQuery<T>(
   Component: Component<T & QueryProps>,
-  query: Query,
+  query?: Query,
   initialSize?: Size
 ): React.ComponentClass<T> {
   return class ContainerQuery extends React.Component<T, State> {
@@ -74,13 +75,13 @@ export function applyContainerQuery<T>(
 
       this.state = {
         params: initialSize
-          ? matchQueries(query)(initialSize)
+          ? matchQueries(query || props.query)(initialSize)
           : {},
       };
     }
 
     componentDidMount() {
-      this.cqCore = new ContainerQueryCore(query, (params) => {
+      this.cqCore = new ContainerQueryCore(query || this.props.query, (params) => {
         this.setState({params});
       });
 
@@ -97,9 +98,10 @@ export function applyContainerQuery<T>(
     }
 
     render() {
+      const { query, ...rest } = this.props;
       return (
         <Component
-          {...this.props}
+          {...rest}
           containerQuery={this.state.params}
         />
       );

--- a/src/interfaces.tsx
+++ b/src/interfaces.tsx
@@ -2,6 +2,11 @@ export interface Props {
   children: ChildFunction;
   query: Query;
   initialSize?: Size;
+  transformQuery: Function;
+}
+
+export interface EnhancedProps {
+  transformQuery: Function;
 }
 
 export interface Size {

--- a/test/client/index.js
+++ b/test/client/index.js
@@ -356,4 +356,20 @@ describe('applyContainerQuery', function () {
     }, 100);
   });
 
+  it('accepts query as prop', function (done) {
+    let _params;
+
+    const Container = applyContainerQuery(function (props) {
+      _params = props.containerQuery;
+      return <div style={{width: '200px'}}></div>;
+    });
+
+    render(<Container query={query}/>, $div);
+
+    setTimeout(() => {
+      expect(_params).toEqual({mobile: true, desktop: false});
+      done();
+    }, 100);
+  });
+
 });

--- a/test/client/index.js
+++ b/test/client/index.js
@@ -188,6 +188,11 @@ describe('applyContainerQuery', function () {
     desktop: {minWidth: 400}
   };
 
+  const extraQuery = {
+    tablet: { minWidth: 700 },
+    desktop: { maxWidth: 1200 }
+  };
+
   let $div;
 
   beforeEach(function () {
@@ -356,18 +361,34 @@ describe('applyContainerQuery', function () {
     }, 100);
   });
 
-  it('accepts query as prop', function (done) {
+  it('accepts transformQuery prop', function (done) {
     let _params;
 
     const Container = applyContainerQuery(function (props) {
       _params = props.containerQuery;
       return <div style={{width: '200px'}}></div>;
-    });
+    }, {});
 
-    render(<Container query={query}/>, $div);
+    render(<Container transformQuery={() => extraQuery}/>, $div);
 
     setTimeout(() => {
-      expect(_params).toEqual({mobile: true, desktop: false});
+      expect(_params).toEqual({tablet: false, desktop: true});
+      done();
+    }, 100);
+  });
+
+  it('extends base query', function (done) {
+    let _params;
+
+    const Container = applyContainerQuery(function (props) {
+      _params = props.containerQuery;
+      return <div style={{width: '200px'}}></div>;
+    }, query);
+
+    render(<Container transformQuery={(baseQuery) => ({ ...baseQuery, ...extraQuery })}/>, $div);
+
+    setTimeout(() => {
+      expect(_params).toEqual({mobile: true, tablet: false, desktop: true});
       done();
     }, 100);
   });


### PR DESCRIPTION
Not a breaking change as it makes `query` in applyContainerQuery() optional.

Usage: 
```javascript
// Foo.js
const Foo  = ({ query }) => <Container query={query} />;
export default Foo;

// Container.js
const Container = ({ containerQuery }) => ...
export default applyContainerQuery(Container);
```
