### PR TITLE
fix: readme.md installation example

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@
 ## Installation
 
 ```sh
-npm i -D react-container-query
+npm i react-container-query
 ```
 
 ## Disclaimer


### PR DESCRIPTION
Why save as dev-dep? shouldn't this be a regular dep?